### PR TITLE
Upgrade example 03 to use rendr@1.0.1

### DIFF
--- a/03_sessions/app/app.js
+++ b/03_sessions/app/app.js
@@ -9,14 +9,14 @@ module.exports = BaseApp.extend({
   /**
    * Client and server.
    *
-   * `postInitialize` is called on app initialize, both on the client and server.
+   * `initialize` is called on app initialize, both on the client and server.
    * On the server, an app is instantiated once for each request, and in the
    * client, it's instantiated once on page load.
    *
    * This is a good place to initialize any code that needs to be available to
    * app on both client and server.
    */
-  postInitialize: function() {
+  initialize: function() {
     /**
      * Register our Handlebars helpers.
      *

--- a/03_sessions/app/router.js
+++ b/03_sessions/app/router.js
@@ -10,7 +10,7 @@ var Router = module.exports = function Router(options) {
 Router.prototype = Object.create(BaseClientRouter.prototype);
 Router.prototype.constructor = BaseClientRouter;
 
-Router.prototype.postInitialize = function() {
+Router.prototype.initialize = function() {
   this.on('action:start', this.trackImpression, this);
 };
 

--- a/03_sessions/index.js
+++ b/03_sessions/index.js
@@ -1,33 +1,33 @@
 var express = require('express')
   , rendr = require('rendr')
   , config = require('config')
+  , compress = require('compression')
+  , bodyParser = require('body-parser')
+  , serveStatic = require('serve-static')
+  , cookieParser = require('cookie-parser')
+  , session = require('express-session')
   , mw = require('./server/middleware')
   , app = express();
 
 /**
  * Initialize Express middleware stack.
  */
-app.use(express.compress());
-app.use(express.static(__dirname + '/public'));
-app.use(express.logger());
-app.use(express.bodyParser());
+app.use(compress());
+app.use(serveStatic(__dirname + '/public'));
+app.use(bodyParser.json());
 
 /**
  * The `cookieParser` middleware is required for sessions.
  */
-app.use(express.cookieParser());
+app.use(cookieParser());
 
 /**
  * Add session support. This will populate `req.session`.
  */
-app.use(express.session({
+app.use(session({
   secret: config.session.secret,
-
-  /**
-   * In production apps, you should probably use something like Redis or Memcached
-   * to store sessions. Look at the `connect-redis` or `connect-memcached` modules.
-   */
-  store: null
+  resave: false,
+  saveUninitialized: true
 }));
 
 /**
@@ -45,7 +45,7 @@ var server = rendr.createServer({
   *
   *     app.use('/my_cool_app', server);
   */
-app.use(server);
+app.use('/', server.expressApp);
 
 server.configure(function(rendrExpressApp) {
 

--- a/03_sessions/package.json
+++ b/03_sessions/package.json
@@ -1,35 +1,45 @@
 {
   "name": "rendr-example",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --ui bdd --reporter spec  ./test --recursive",
+    "test": "mocha --ui bdd --reporter spec ./test --recursive",
     "start": "node index.js",
     "postinstall": "test -f ../../package.json && npm install ../../ || echo",
     "postupdate": "test -f ../../package.json && npm install ../../ || echo"
   },
   "dependencies": {
-    "express": "~3",
-    "underscore": "~1.5.2",
-    "async": "~0.1.22",
-    "rendr-handlebars": "0.2.0",
-    "rendr": "0.5.0",
-    "config": "~0.4.30",
-    "js-yaml": "2.x.x"
+    "async": "^0.9.0",
+    "body-parser": "^1.12.0",
+    "compression": "^1.4.1",
+    "config": "^1.12.0",
+    "cookie-parser": "^1.3.4",
+    "express": "^4.12.0",
+    "express-session": "^1.10.3",
+    "jquery": "^2.1.3",
+    "js-yaml": "^3.2.7",
+    "rendr": "^1.0.1",
+    "rendr-handlebars": "^1.0.0",
+    "serve-static": "^1.9.1",
+    "should": "^5.0.1",
+    "underscore": "^1.8.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-browserify": "~1.2.9",
-    "grunt-contrib-stylus": "~0.5.0",
-    "grunt-contrib-handlebars": "~0.5.11",
-    "grunt-contrib-watch": "~0.3.1",
-    "nodemon": "~0.7.6",
-    "mocha": "~1.9.0",
-    "should": "~1.2.2"
+    "chai": "~2.1.0",
+    "grunt": "~0.4.5",
+    "grunt-browserify": "^1.2.12",
+    "grunt-contrib-handlebars": "~0.9.3",
+    "grunt-contrib-stylus": "~0.20.0",
+    "grunt-contrib-watch": "~0.6.1",
+    "karma": "~0.12.31",
+    "karma-chrome-launcher": "~0.1.7",
+    "karma-mocha": "~0.1.10",
+    "mocha": "~2.1.0",
+    "nodemon": "^0.7.10"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.10"
   },
   "private": true
 }


### PR DESCRIPTION
- updated to use express-session module
- update all the modules (express, rendr, rendr-handlebars)
- add compression, body-parser, serve-static, cookie-parser, and express-session to go with the upgrade to express 4.12.0