### PR TITLE
Upgrade 04 to use rendr@1.0.1

### DIFF
--- a/01_config/package.json
+++ b/01_config/package.json
@@ -19,20 +19,16 @@
     "rendr": "^1.0.1",
     "rendr-handlebars": "^1.0.0",
     "serve-static": "^1.9.1",
-    "should": "^5.0.1",
     "underscore": "^1.8.2"
   },
   "devDependencies": {
     "browserify": "^2.36.1",
-    "chai": "~2.1.0",
     "grunt": "~0.4.5",
     "grunt-browserify": "^1.2.12",
     "grunt-contrib-handlebars": "~0.9.3",
     "grunt-contrib-stylus": "~0.20.0",
     "grunt-contrib-watch": "~0.6.1",
-    "karma": "~0.12.31",
-    "karma-chrome-launcher": "~0.1.7",
-    "karma-mocha": "~0.1.10",
+    "should": "^5.0.1",
     "mocha": "~2.1.0",
     "nodemon": "^0.7.10"
   },

--- a/02_middleware/package.json
+++ b/02_middleware/package.json
@@ -20,19 +20,15 @@
     "rendr": "^1.0.1",
     "rendr-handlebars": "^1.0.0",
     "serve-static": "^1.9.1",
-    "should": "^5.0.1",
     "underscore": "^1.8.2"
   },
   "devDependencies": {
-    "chai": "~2.1.0",
     "grunt": "~0.4.5",
     "grunt-browserify": "^1.2.12",
     "grunt-contrib-handlebars": "~0.9.3",
     "grunt-contrib-stylus": "~0.20.0",
     "grunt-contrib-watch": "~0.6.1",
-    "karma": "~0.12.31",
-    "karma-chrome-launcher": "~0.1.7",
-    "karma-mocha": "~0.1.10",
+    "should": "^5.0.1",
     "mocha": "~2.1.0",
     "nodemon": "^0.7.10"
   },

--- a/03_sessions/package.json
+++ b/03_sessions/package.json
@@ -22,19 +22,15 @@
     "rendr": "^1.0.1",
     "rendr-handlebars": "^1.0.0",
     "serve-static": "^1.9.1",
-    "should": "^5.0.1",
     "underscore": "^1.8.2"
   },
   "devDependencies": {
-    "chai": "~2.1.0",
     "grunt": "~0.4.5",
     "grunt-browserify": "^1.2.12",
     "grunt-contrib-handlebars": "~0.9.3",
     "grunt-contrib-stylus": "~0.20.0",
     "grunt-contrib-watch": "~0.6.1",
-    "karma": "~0.12.31",
-    "karma-chrome-launcher": "~0.1.7",
-    "karma-mocha": "~0.1.10",
+    "should": "^5.0.1",
     "mocha": "~2.1.0",
     "nodemon": "^0.7.10"
   },

--- a/04_entrypath/apps/main/app/app.js
+++ b/04_entrypath/apps/main/app/app.js
@@ -9,14 +9,14 @@ module.exports = BaseApp.extend({
   /**
    * Client and server.
    *
-   * `postInitialize` is called on app initialize, both on the client and server.
+   * `initialize` is called on app initialize, both on the client and server.
    * On the server, an app is instantiated once for each request, and in the
    * client, it's instantiated once on page load.
    *
    * This is a good place to initialize any code that needs to be available to
    * app on both client and server.
    */
-  postInitialize: function() {
+  initialize: function() {
     /**
      * Register our Handlebars helpers.
      *

--- a/04_entrypath/apps/main/app/router.js
+++ b/04_entrypath/apps/main/app/router.js
@@ -10,7 +10,7 @@ var Router = module.exports = function Router(options) {
 Router.prototype = Object.create(BaseClientRouter.prototype);
 Router.prototype.constructor = BaseClientRouter;
 
-Router.prototype.postInitialize = function() {
+Router.prototype.initialize = function() {
   this.on('action:start', this.trackImpression, this);
 };
 

--- a/04_entrypath/apps/main/index.js
+++ b/04_entrypath/apps/main/index.js
@@ -1,7 +1,6 @@
 var rendr = require('rendr')
   , config = require('config');
 
-
 /**
  * Initialize our Rendr server and export it, so it can be used as a middleware
  * by our top-level `index.js`.

--- a/04_entrypath/index.js
+++ b/04_entrypath/index.js
@@ -2,15 +2,17 @@ var express = require('express')
   , config = require('config')
   , app = express()
   , mainApp = require('./apps/main')
-  , landingPageApp = require('./apps/landing_page');
+  , landingPageApp = require('./apps/landing_page')
+  , compress = require('compression')
+  , bodyParser = require('body-parser')
+  , serveStatic = require('serve-static');
 
 /**
  * Initialize Express middleware stack.
  */
-app.use(express.compress());
-app.use(express.static(__dirname + '/public'));
-app.use(express.logger());
-app.use(express.bodyParser());
+app.use(compress());
+app.use(serveStatic(__dirname + '/public'));
+app.use(bodyParser.json());
 
 /**
  * Mount a simple, self-contained landing page app as an Express sub-app.
@@ -20,7 +22,9 @@ app.use('/landing_page', landingPageApp);
 /**
  * Mount the Rendr app at the root level.
  */
-app.use(mainApp);
+mainApp.configure(function (expressApp) {
+  app.use('/', expressApp);
+})
 
 /**
  * Start the Express server.

--- a/04_entrypath/package.json
+++ b/04_entrypath/package.json
@@ -1,36 +1,39 @@
 {
   "name": "rendr-example",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --ui bdd --reporter spec  ./test --recursive",
+    "test": "mocha --ui bdd --reporter spec ./test --recursive",
     "start": "node index.js",
     "postinstall": "test -f ../../package.json && npm install ../../ || echo",
     "postupdate": "test -f ../../package.json && npm install ../../ || echo"
   },
   "dependencies": {
-    "express": "~3",
-    "underscore": "~1.5.2",
-    "async": "~0.1.22",
-    "rendr-handlebars": "0.2.0",
-    "rendr": "0.5.0",
-    "config": "~0.4.30",
-    "js-yaml": "2.x.x",
-    "hbs": "~2.4.0"
+    "body-parser": "^1.12.0",
+    "compression": "^1.4.1",
+    "config": "^1.12.0",
+    "express": "^4.12.0",
+    "hbs": "^2.8.0",
+    "jquery": "^2.1.3",
+    "js-yaml": "^3.2.7",
+    "rendr": "^1.0.1",
+    "rendr-handlebars": "^1.0.0",
+    "serve-static": "^1.9.1",
+    "underscore": "^1.8.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-browserify": "~1.2.9",
-    "grunt-contrib-stylus": "~0.5.0",
-    "grunt-contrib-handlebars": "~0.5.11",
-    "grunt-contrib-watch": "~0.3.1",
-    "nodemon": "~0.7.6",
-    "mocha": "~1.9.0",
-    "should": "~1.2.2"
+    "grunt": "~0.4.5",
+    "grunt-browserify": "^1.2.12",
+    "grunt-contrib-handlebars": "~0.9.3",
+    "grunt-contrib-stylus": "~0.20.0",
+    "grunt-contrib-watch": "~0.6.1",
+    "mocha": "~2.1.0",
+    "nodemon": "^0.7.10",
+    "should": "^5.0.1"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.10"
   },
   "private": true
 }


### PR DESCRIPTION
for example 04
- upgrades to use express 4
- upgraded dependencies
- mount to the main app in a configure callback

cleaned up 01, 02, 03 `package.json` files which had carryover from example 00 (whoops)