### PR TITLE
Upgrade 06 to rendr 1.0.1

### DIFF
--- a/06_appview/app/app.js
+++ b/06_appview/app/app.js
@@ -9,14 +9,14 @@ module.exports = BaseApp.extend({
   /**
    * Client and server.
    *
-   * `postInitialize` is called on app initialize, both on the client and server.
+   * `initialize` is called on app initialize, both on the client and server.
    * On the server, an app is instantiated once for each request, and in the
    * client, it's instantiated once on page load.
    *
    * This is a good place to initialize any code that needs to be available to
    * app on both client and server.
    */
-  postInitialize: function() {
+  initialize: function() {
     /**
      * Register our Handlebars helpers.
      *

--- a/06_appview/app/router.js
+++ b/06_appview/app/router.js
@@ -10,7 +10,7 @@ var Router = module.exports = function Router(options) {
 Router.prototype = Object.create(BaseClientRouter.prototype);
 Router.prototype.constructor = BaseClientRouter;
 
-Router.prototype.postInitialize = function() {
+Router.prototype.initialize = function() {
   this.on('action:start', this.trackImpression, this);
 };
 

--- a/06_appview/app/views/app_view.js
+++ b/06_appview/app/views/app_view.js
@@ -4,7 +4,7 @@ var BaseAppView = require('rendr/client/app_view')
 ;
 
 module.exports = BaseAppView.extend({
-  postInitialize: function() {
+  initialize: function() {
     this.app.on('change:loading', function(app, loading) {
       $body.toggleClass('loading', loading);
     });

--- a/06_appview/index.js
+++ b/06_appview/index.js
@@ -1,14 +1,16 @@
 var express = require('express')
   , rendr = require('rendr')
+  , compress = require('compression')
+  , bodyParser = require('body-parser')
+  , serveStatic = require('serve-static')
   , app = express();
 
 /**
  * Initialize Express middleware stack.
  */
-app.use(express.compress());
-app.use(express.static(__dirname + '/public'));
-app.use(express.logger());
-app.use(express.bodyParser());
+app.use(compress());
+app.use(serveStatic(__dirname + '/public'));
+app.use(bodyParser.json());
 
 /**
  * In this simple example, the DataAdapter config, which specifies host, port, etc. of the API
@@ -42,7 +44,10 @@ var server = rendr.createServer({
   *
   *     app.use('/my_cool_app', server);
   */
-app.use(server);
+
+server.configure(function (expressApp) {
+  app.use('/', expressApp);
+});
 
 /**
  * Start the Express server.

--- a/06_appview/index.js
+++ b/06_appview/index.js
@@ -3,6 +3,7 @@ var express = require('express')
   , compress = require('compression')
   , bodyParser = require('body-parser')
   , serveStatic = require('serve-static')
+  , logger = require('morgan')
   , app = express();
 
 /**
@@ -10,6 +11,7 @@ var express = require('express')
  */
 app.use(compress());
 app.use(serveStatic(__dirname + '/public'));
+app.use(logger('combined'));
 app.use(bodyParser.json());
 
 /**

--- a/06_appview/package.json
+++ b/06_appview/package.json
@@ -1,36 +1,42 @@
 {
   "name": "rendr-example",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "grunt compile && mocha --ui bdd --reporter spec ./test/app --recursive && karma start test/karma.config.js --single-run",
+    "test": "npm run test-unit && npm run test-karma",
+    "test-unit": "mocha --ui bdd --reporter spec ./test/app --recursive",
+    "test-karma": "grunt compile && ./node_modules/karma/bin/karma start test/karma.config.js --single-run",
     "start": "node index.js",
     "postinstall": "test -f ../../package.json && npm install ../../ || echo",
     "postupdate": "test -f ../../package.json && npm install ../../ || echo"
   },
   "dependencies": {
-    "express": "~3",
-    "underscore": "~1.5.2",
-    "async": "~0.1.22",
-    "rendr-handlebars": "0.2.0",
-    "rendr": "0.5.0"
+    "async": "^0.9.0",
+    "body-parser": "^1.12.0",
+    "compression": "^1.4.1",
+    "express": "^4.12.0",
+    "jquery": "^2.1.3",
+    "rendr": "^1.0.1",
+    "rendr-handlebars": "^1.0.0",
+    "serve-static": "^1.9.1",
+    "underscore": "^1.8.2"
   },
   "devDependencies": {
-    "grunt": "~0.4.1",
-    "grunt-browserify": "~1.2.9",
-    "grunt-contrib-stylus": "~0.5.0",
-    "grunt-contrib-handlebars": "~0.5.11",
-    "grunt-contrib-watch": "~0.3.1",
-    "nodemon": "~0.7.6",
-    "mocha": "~1.9.0",
-    "chai": "~1.8.1",
-    "karma": "~0.10.4",
-    "karma-chrome-launcher": "~0.1.0",
-    "karma-mocha": "~0.1.0"
+    "grunt": "~0.4.5",
+    "grunt-browserify": "~1.2.12",
+    "grunt-contrib-stylus": "~0.20.0",
+    "grunt-contrib-handlebars": "~0.9.3",
+    "grunt-contrib-watch": "~0.6.1",
+    "mocha": "~2.1.0",
+    "nodemon": "^0.7.10",
+    "chai": "~2.1.0",
+    "karma": "~0.12.31",
+    "karma-chrome-launcher": "~0.1.7",
+    "karma-mocha": "~0.1.10"
   },
   "engines": {
-    "node": ">=0.8"
+    "node": ">=0.10"
   },
   "private": true
 }

--- a/06_appview/package.json
+++ b/06_appview/package.json
@@ -17,6 +17,7 @@
     "compression": "^1.4.1",
     "express": "^4.12.0",
     "jquery": "^2.1.3",
+    "morgan": "^1.5.1",
     "rendr": "^1.0.1",
     "rendr-handlebars": "^1.0.0",
     "serve-static": "^1.9.1",


### PR DESCRIPTION
- Upgrade index to use express 4.12.0, and all the extras that are no
  longer included in express
- updated postInitialize -> initialize
- updated all the remaining dependencies
- added morgan to log incoming requests