### PR TITLE
fix: users collection is not strictly made up of user model instances

### DIFF
--- a/00_simple/app/collections/users.js
+++ b/00_simple/app/collections/users.js
@@ -1,8 +1,6 @@
-var User = require('../models/user')
-  , Base = require('./base');
+var Base = require('./base');
 
 module.exports = Base.extend({
-  model: User,
   url: '/users'
 });
 module.exports.id = 'Users';

--- a/01_config/app/collections/users.js
+++ b/01_config/app/collections/users.js
@@ -1,8 +1,6 @@
-var User = require('../models/user')
-  , Base = require('./base');
+var Base = require('./base');
 
 module.exports = Base.extend({
-  model: User,
   url: '/users'
 });
 module.exports.id = 'Users';

--- a/02_middleware/app/collections/users.js
+++ b/02_middleware/app/collections/users.js
@@ -1,8 +1,6 @@
-var User = require('../models/user')
-  , Base = require('./base');
+var Base = require('./base');
 
 module.exports = Base.extend({
-  model: User,
   url: '/users'
 });
 module.exports.id = 'Users';

--- a/03_sessions/app/collections/users.js
+++ b/03_sessions/app/collections/users.js
@@ -1,8 +1,6 @@
-var User = require('../models/user')
-  , Base = require('./base');
+var Base = require('./base');
 
 module.exports = Base.extend({
-  model: User,
   url: '/users'
 });
 module.exports.id = 'Users';

--- a/04_entrypath/apps/main/app/collections/users.js
+++ b/04_entrypath/apps/main/app/collections/users.js
@@ -1,8 +1,6 @@
-var User = require('../models/user')
-  , Base = require('./base');
+var Base = require('./base');
 
 module.exports = Base.extend({
-  model: User,
   url: '/users'
 });
 module.exports.id = 'Users';

--- a/05_requirejs/app/collections/users.js
+++ b/05_requirejs/app/collections/users.js
@@ -4,11 +4,9 @@ if (typeof define !== 'function') {
 
 define(function(require) {
 
-  var User = require('../models/user')
-    , Base = require('./base');
+  var Base = require('./base');
 
   var exports = Base.extend({
-    model: User,
     url: '/users'
   });
   exports.id = 'Users';

--- a/06_appview/app/collections/users.js
+++ b/06_appview/app/collections/users.js
@@ -1,8 +1,6 @@
-var User = require('../models/user')
-  , Base = require('./base');
+var Base = require('./base');
 
 module.exports = Base.extend({
-  model: User,
   url: '/users'
 });
 module.exports.id = 'Users';


### PR DESCRIPTION
I noticed that currently, client-side navigation to a user show page results in a lot of missing attributes:
![screen shot 2015-04-14 at 12 00 03 am](https://cloud.githubusercontent.com/assets/5355769/7131951/8c3584d0-e239-11e4-8c40-24c875dbf4e9.png)

But a server-side refresh has all the attributes filled in:
![screen shot 2015-04-14 at 12 00 23 am](https://cloud.githubusercontent.com/assets/5355769/7131962/a5520600-e239-11e4-9a2c-1894d69ea9fb.png)

The issue lies in the fact that the Github API returns a more barebones JSON blob for each user entry in the collection at the /users endpoint.  Compare the first element in https://api.github.com/users  to  https://api.github.com/users/mojombo

When the fetcher gets the collection back from the call to https://api.github.com/users, it iterates through and populates the client model store with each of these barebones user entries.  This change makes it explicit that the users collection is not strictly made of user model instances, and has the effect that it does not fill the client model store with barebones user entries that don't have the displayed attributes.
