### PR TITLE
update all example apps to include handlebars dependency

### DIFF
--- a/00_simple/Gruntfile.js
+++ b/00_simple/Gruntfile.js
@@ -67,6 +67,7 @@ module.exports = function(grunt) {
       options: {
         debug: true,
         alias: [
+          'node_modules/handlebars/runtime.js:handlebars',
           'node_modules/rendr-handlebars/index.js:rendr-handlebars'
         ],
         aliasMappings: [

--- a/00_simple/package.json
+++ b/00_simple/package.json
@@ -15,6 +15,7 @@
     "body-parser": "^1.12.0",
     "compression": "^1.4.1",
     "express": "^4.12.0",
+    "handlebars": "^2.0.0",
     "jquery": "^2.1.3",
     "rendr": "^1.0.1",
     "rendr-handlebars": "^1.0.0",

--- a/01_config/Gruntfile.js
+++ b/01_config/Gruntfile.js
@@ -75,6 +75,7 @@ module.exports = function(grunt) {
         options: {
           debug: true,
           alias: [
+            'node_modules/handlebars/runtime.js:handlebars',
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],
           aliasMappings: [

--- a/01_config/package.json
+++ b/01_config/package.json
@@ -14,6 +14,7 @@
     "compression": "^1.4.1",
     "config": "^1.12.0",
     "express": "^4.12.0",
+    "handlebars": "^2.0.0",
     "jquery": "^2.1.3",
     "js-yaml": "^3.2.7",
     "rendr": "^1.0.1",

--- a/02_middleware/Gruntfile.js
+++ b/02_middleware/Gruntfile.js
@@ -75,6 +75,7 @@ module.exports = function(grunt) {
         options: {
           debug: true,
           alias: [
+            'node_modules/handlebars/runtime.js:handlebars',
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],
           aliasMappings: [

--- a/02_middleware/package.json
+++ b/02_middleware/package.json
@@ -15,6 +15,7 @@
     "compression": "^1.4.1",
     "config": "^1.12.0",
     "express": "^4.12.0",
+    "handlebars": "^2.0.0",
     "jquery": "^2.1.3",
     "js-yaml": "^3.2.7",
     "rendr": "^1.0.1",

--- a/03_sessions/Gruntfile.js
+++ b/03_sessions/Gruntfile.js
@@ -75,6 +75,7 @@ module.exports = function(grunt) {
         options: {
           debug: true,
           alias: [
+            'node_modules/handlebars/runtime.js:handlebars',
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],
           aliasMappings: [

--- a/03_sessions/package.json
+++ b/03_sessions/package.json
@@ -17,6 +17,7 @@
     "cookie-parser": "^1.3.4",
     "express": "^4.12.0",
     "express-session": "^1.10.3",
+    "handlebars": "^2.0.0",
     "jquery": "^2.1.3",
     "js-yaml": "^3.2.7",
     "rendr": "^1.0.1",

--- a/04_entrypath/Gruntfile.js
+++ b/04_entrypath/Gruntfile.js
@@ -72,6 +72,7 @@ module.exports = function(grunt) {
         options: {
           debug: true,
           alias: [
+            'node_modules/handlebars/runtime.js:handlebars',
             'node_modules/rendr-handlebars/index.js:rendr-handlebars',
           ],
           aliasMappings: [

--- a/04_entrypath/package.json
+++ b/04_entrypath/package.json
@@ -14,6 +14,7 @@
     "compression": "^1.4.1",
     "config": "^1.12.0",
     "express": "^4.12.0",
+    "handlebars": "^2.0.0",
     "hbs": "^2.8.0",
     "jquery": "^2.1.3",
     "js-yaml": "^3.2.7",

--- a/05_requirejs/Gruntfile.js
+++ b/05_requirejs/Gruntfile.js
@@ -126,7 +126,7 @@ module.exports = function(grunt) {
             {name: 'requirejs', location: 'requirejs', main: 'require.js'},
             {name: 'underscore', location: 'underscore', main: 'underscore.js'},
             {name: 'backbone', location: 'backbone', main: 'backbone.js'},
-            {name: 'handlebars', location: 'rendr-handlebars/node_modules/handlebars/dist', main: 'handlebars.runtime.js'},
+            {name: 'handlebars', location: 'handlebars', main: 'runtime.js'},
             {name: 'async', location: 'async/lib', main: 'async.js'}
           ]
         }

--- a/05_requirejs/package.json
+++ b/05_requirejs/package.json
@@ -14,6 +14,7 @@
     "body-parser": "^1.12.0",
     "compression": "^1.4.1",
     "express": "^4.12.0",
+    "handlebars": "^2.0.0",
     "jquery": "^2.1.3",
     "rendr": "^1.0.3",
     "rendr-handlebars": "^1.0.0",

--- a/06_appview/Gruntfile.js
+++ b/06_appview/Gruntfile.js
@@ -70,6 +70,7 @@ module.exports = function(grunt) {
       options: {
         debug: true,
         alias: [
+          'node_modules/handlebars/runtime.js:handlebars',
           'node_modules/rendr-handlebars/index.js:rendr-handlebars'
         ],
         aliasMappings: [

--- a/06_appview/package.json
+++ b/06_appview/package.json
@@ -16,6 +16,7 @@
     "body-parser": "^1.12.0",
     "compression": "^1.4.1",
     "express": "^4.12.0",
+    "handlebars": "^2.0.0",
     "jquery": "^2.1.3",
     "morgan": "^1.5.1",
     "rendr": "^1.0.1",


### PR DESCRIPTION
Since Rendr 1.0.4, we need our Rendr app to include its template engine of choice, which by default is still Handlebars. This PR updates all the examples app package.json and tests.
